### PR TITLE
MM-34366: Migrate 'components/post_view/post_list_virtualized' and associated tests to TypeScript

### DIFF
--- a/components/post_view/post_list_virtualized/post_list_virtualized.test.tsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.test.tsx
@@ -12,7 +12,7 @@ import {PostListRowListIds, PostRequestTypes} from 'utils/constants';
 
 import PostListRow from 'components/post_view/post_list_row';
 
-import PostList from './post_list_virtualized';
+import PostList, {PostListType} from './post_list_virtualized';
 
 describe('PostList', () => {
     const baseActions = {
@@ -56,7 +56,8 @@ describe('PostList', () => {
 
         test('should get previous item ID correctly for oldest row', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
+
             const row = shallow(instance.renderRow({
                 data: postListIds,
                 itemId: 'd',
@@ -67,7 +68,7 @@ describe('PostList', () => {
 
         test('should get previous item ID correctly for other rows', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
             const row = shallow(instance.renderRow({
                 data: postListIds,
                 itemId: 'b',
@@ -83,14 +84,15 @@ describe('PostList', () => {
             };
 
             const wrapper = shallowWithIntl(<PostList {...props}/>);
+            const instance = wrapper.instance() as PostListType;
 
-            let row = shallow(wrapper.instance().renderRow({
+            let row = shallow(instance.renderRow({
                 data: postListIds,
                 itemId: 'c',
             }));
             expect(row.find(PostListRow).prop('shouldHighlight')).toEqual(false);
 
-            row = shallow(wrapper.instance().renderRow({
+            row = shallow(instance.renderRow({
                 data: postListIds,
                 itemId: 'b',
             }));
@@ -101,13 +103,14 @@ describe('PostList', () => {
     describe('onScroll', () => {
         test('should call checkBottom', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            wrapper.instance().checkBottom = jest.fn();
+            const instance = wrapper.instance() as PostListType;
+            instance.checkBottom = jest.fn();
 
             const scrollOffset = 1234;
             const scrollHeight = 1000;
             const clientHeight = 500;
 
-            wrapper.instance().onScroll({
+            instance.onScroll({
                 scrollDirection: 'forward',
                 scrollOffset,
                 scrollUpdateWasRequested: false,
@@ -115,12 +118,12 @@ describe('PostList', () => {
                 clientHeight,
             });
 
-            expect(wrapper.instance().checkBottom).toHaveBeenCalledWith(scrollOffset, scrollHeight, clientHeight);
+            expect(instance.checkBottom).toHaveBeenCalledWith(scrollOffset, scrollHeight, clientHeight);
         });
 
         test('should call canLoadMorePosts with AFTER_ID if loader is visible', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
 
             const scrollOffset = 1234;
             const scrollHeight = 1000;
@@ -140,7 +143,7 @@ describe('PostList', () => {
 
         test('should not call canLoadMorePosts with AFTER_ID if loader is below the fold by couple of messages', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
 
             const scrollOffset = 1234;
             const scrollHeight = 1000;
@@ -162,7 +165,7 @@ describe('PostList', () => {
             const screenHeightSpy = jest.spyOn(window.screen, 'height', 'get').mockImplementation(() => 500);
 
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
 
             const scrollHeight = 3000;
             const clientHeight = 500;
@@ -185,7 +188,7 @@ describe('PostList', () => {
             const screenHeightSpy = jest.spyOn(window.screen, 'height', 'get').mockImplementation(() => 500);
 
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
 
             const scrollHeight = 3000;
             const clientHeight = 500;
@@ -208,7 +211,7 @@ describe('PostList', () => {
             const screenHeightSpy = jest.spyOn(window.screen, 'height', 'get').mockImplementation(() => 500);
 
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
 
             const scrollHeight = 3000;
             const clientHeight = 500;
@@ -233,7 +236,7 @@ describe('PostList', () => {
 
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             wrapper.setState({isMobile: true});
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
 
             const scrollHeight = 3000;
             const clientHeight = 500;
@@ -255,7 +258,7 @@ describe('PostList', () => {
         test('should not show search channel hint if it has already been dismissed', () => {
             const screenHeightSpy = jest.spyOn(window.screen, 'height', 'get').mockImplementation(() => 500);
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
 
             const scrollHeight = 3000;
             const clientHeight = 500;
@@ -279,7 +282,7 @@ describe('PostList', () => {
             const screenHeightSpy = jest.spyOn(window.screen, 'height', 'get').mockImplementation(() => 500);
 
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
 
             const scrollHeight = 3000;
             const clientHeight = 500;
@@ -338,7 +341,8 @@ describe('PostList', () => {
         ]) {
             test(testCase.name, () => {
                 const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-                expect(wrapper.instance().isAtBottom(testCase.scrollOffset, scrollHeight, clientHeight)).toBe(testCase.expected);
+                const instance = wrapper.instance() as PostListType;
+                expect(instance.isAtBottom(testCase.scrollOffset, scrollHeight, clientHeight)).toBe(testCase.expected);
             });
         }
     });
@@ -346,9 +350,10 @@ describe('PostList', () => {
     describe('updateAtBottom', () => {
         test('should update atBottom and lastViewedBottom when atBottom changes', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
+            const instance = wrapper.instance() as PostListType;
             wrapper.setState({lastViewedBottom: 1234, atBottom: false});
 
-            wrapper.instance().updateAtBottom(true);
+            instance.updateAtBottom(true);
 
             expect(wrapper.state('atBottom')).toBe(true);
             expect(wrapper.state('lastViewedBottom')).not.toBe(1234);
@@ -356,9 +361,10 @@ describe('PostList', () => {
 
         test('should not update lastViewedBottom when atBottom does not change', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
+            const instance = wrapper.instance() as PostListType;
             wrapper.setState({lastViewedBottom: 1234, atBottom: false});
 
-            wrapper.instance().updateAtBottom(false);
+            instance.updateAtBottom(false);
 
             expect(wrapper.state('lastViewedBottom')).toBe(1234);
         });
@@ -367,9 +373,10 @@ describe('PostList', () => {
             Date.now = jest.fn().mockReturnValue(12344);
 
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
+            const instance = wrapper.instance() as PostListType;
             wrapper.setState({lastViewedBottom: 1234, atBottom: false});
 
-            wrapper.instance().updateAtBottom(true);
+            instance.updateAtBottom(true);
 
             expect(wrapper.state('lastViewedBottom')).toBe(12345);
         });
@@ -378,9 +385,11 @@ describe('PostList', () => {
             Date.now = jest.fn().mockReturnValue(12346);
 
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
+            const instance = wrapper.instance() as PostListType;
+
             wrapper.setState({lastViewedBottom: 1234, atBottom: false});
 
-            wrapper.instance().updateAtBottom(true);
+            instance.updateAtBottom(true);
 
             expect(wrapper.state('lastViewedBottom')).toBe(12346);
         });
@@ -389,7 +398,7 @@ describe('PostList', () => {
     describe('Scroll correction logic on mount of posts at the top', () => {
         test('should return previous scroll position from getSnapshotBeforeUpdate', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
             instance.componentDidUpdate = jest.fn();
 
             instance.postListRef = {current: {scrollHeight: 100, parentElement: {scrollTop: 10}}};
@@ -400,13 +409,15 @@ describe('PostList', () => {
             expect(instance.componentDidUpdate.mock.calls[1][2]).toEqual({previousScrollTop: 10, previousScrollHeight: 100});
 
             instance.postListRef = {current: {scrollHeight: 200, parentElement: {scrollTop: 30}}};
-            wrapper.setProps({postListIds: [
-                'post1',
-                'post2',
-                'post3',
-                DATE_LINE + 1551711600000,
-                'post4',
-            ]});
+            wrapper.setProps({
+                postListIds: [
+                    'post1',
+                    'post2',
+                    'post3',
+                    DATE_LINE + 1551711600000,
+                    'post4',
+                ],
+            });
 
             expect(instance.componentDidUpdate).toHaveBeenCalledTimes(3);
             expect(instance.componentDidUpdate.mock.calls[2][2]).toEqual({previousScrollTop: 30, previousScrollHeight: 200});
@@ -414,7 +425,7 @@ describe('PostList', () => {
 
         test('should not return previous scroll position from getSnapshotBeforeUpdate as list is at bottom', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
             instance.componentDidUpdate = jest.fn();
 
             instance.postListRef = {current: {scrollHeight: 100, parentElement: {scrollTop: 10}}};
@@ -437,7 +448,7 @@ describe('PostList', () => {
             };
 
             const wrapper = shallowWithIntl(<PostList {...props}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
             expect(instance.initRangeToRender).toEqual([0, 50]);
         });
 
@@ -454,7 +465,7 @@ describe('PostList', () => {
             };
 
             const wrapper = shallowWithIntl(<PostList {...props}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
             expect(instance.initRangeToRender).toEqual([35, 95]);
         });
     });
@@ -467,7 +478,7 @@ describe('PostList', () => {
             };
 
             const wrapper = shallowWithIntl(<PostList {...props}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
             const post3Row = shallow(instance.renderRow({
                 data: postListIdsForClassNames,
                 itemId: 'post3',
@@ -497,8 +508,9 @@ describe('PostList', () => {
             };
 
             const wrapper = shallowWithIntl(<PostList {...props}/>);
+            const instance = wrapper.instance() as PostListType;
 
-            const row = shallow(wrapper.instance().renderRow({
+            const row = shallow(instance.renderRow({
                 data: props.postListIds,
                 itemId: 'post4',
             }));
@@ -521,8 +533,9 @@ describe('PostList', () => {
             };
 
             const wrapper = shallowWithIntl(<PostList {...props}/>);
+            const instance = wrapper.instance() as PostListType;
 
-            const row = shallow(wrapper.instance().renderRow({
+            const row = shallow(instance.renderRow({
                 data: props.postListIds,
                 itemId: 'post2',
             }));
@@ -534,7 +547,7 @@ describe('PostList', () => {
     describe('updateFloatingTimestamp', () => {
         test('should not update topPostId as is it not mobile view', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
             wrapper.setState({isMobile: false});
             instance.onItemsRendered({visibleStartIndex: 0});
             expect(wrapper.state('topPostId')).toBe('');
@@ -542,7 +555,7 @@ describe('PostList', () => {
 
         test('should update topPostId with latest visible postId', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
             wrapper.setState({isMobile: true});
             instance.onItemsRendered({visibleStartIndex: 1});
             expect(wrapper.state('topPostId')).toBe('post2');
@@ -556,7 +569,7 @@ describe('PostList', () => {
         test('should call scrollToBottom', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             wrapper.setProps({atLatestPost: true});
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
             instance.scrollToBottom = jest.fn();
             instance.scrollToLatestMessages();
             expect(instance.scrollToBottom).toHaveBeenCalled();
@@ -564,8 +577,9 @@ describe('PostList', () => {
 
         test('should call changeUnreadChunkTimeStamp', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
             instance.scrollToLatestMessages();
+
             expect(baseActions.changeUnreadChunkTimeStamp).toHaveBeenCalledWith('');
         });
     });
@@ -574,7 +588,8 @@ describe('PostList', () => {
         test('should have LOAD_NEWER_MESSAGES_TRIGGER and LOAD_OLDER_MESSAGES_TRIGGER', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             wrapper.setProps({autoRetryEnable: false});
-            const postListIdsState = wrapper.state('postListIds');
+
+            const postListIdsState: string[] = wrapper.state('postListIds');
             expect(postListIdsState[0]).toBe(PostListRowListIds.LOAD_NEWER_MESSAGES_TRIGGER);
             expect(postListIdsState[postListIdsState.length - 1]).toBe(PostListRowListIds.LOAD_OLDER_MESSAGES_TRIGGER);
         });
@@ -598,7 +613,7 @@ describe('PostList', () => {
             };
 
             const wrapper = shallowWithIntl(<PostList {...props}/>);
-            const instance = wrapper.instance();
+            const instance = wrapper.instance() as PostListType;
             const initScrollToIndex = instance.initScrollToIndex();
             expect(initScrollToIndex).toEqual({index: 6, position: 'start', offset: -50});
         });
@@ -620,7 +635,7 @@ describe('PostList', () => {
         };
 
         const wrapper = shallowWithIntl(<PostList {...props}/>);
-        const instance = wrapper.instance();
+        const instance = wrapper.instance() as PostListType;
         const initScrollToIndex = instance.initScrollToIndex();
         expect(initScrollToIndex).toEqual({index: 5, position: 'start', offset: -50});
     });

--- a/components/post_view/post_list_virtualized/post_list_virtualized.test.tsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.test.tsx
@@ -399,14 +399,14 @@ describe('PostList', () => {
         test('should return previous scroll position from getSnapshotBeforeUpdate', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             const instance = wrapper.instance() as PostListType;
-            instance.componentDidUpdate = jest.fn();
+            const spy = jest.spyOn(instance, 'componentDidUpdate');
 
             instance.postListRef = {current: {scrollHeight: 100, parentElement: {scrollTop: 10}}};
 
             wrapper.setState({atBottom: false});
             wrapper.setProps({atOldestPost: true});
             expect(instance.componentDidUpdate).toHaveBeenCalledTimes(2);
-            expect(instance.componentDidUpdate.mock.calls[1][2]).toEqual({previousScrollTop: 10, previousScrollHeight: 100});
+            expect(spy.mock.calls[1][2]).toEqual({previousScrollTop: 10, previousScrollHeight: 100});
 
             instance.postListRef = {current: {scrollHeight: 200, parentElement: {scrollTop: 30}}};
             wrapper.setProps({
@@ -420,18 +420,18 @@ describe('PostList', () => {
             });
 
             expect(instance.componentDidUpdate).toHaveBeenCalledTimes(3);
-            expect(instance.componentDidUpdate.mock.calls[2][2]).toEqual({previousScrollTop: 30, previousScrollHeight: 200});
+            expect(spy.mock.calls[2][2]).toEqual({previousScrollTop: 30, previousScrollHeight: 200});
         });
 
         test('should not return previous scroll position from getSnapshotBeforeUpdate as list is at bottom', () => {
             const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             const instance = wrapper.instance() as PostListType;
-            instance.componentDidUpdate = jest.fn();
+            const spy = jest.spyOn(instance, 'componentDidUpdate');
 
             instance.postListRef = {current: {scrollHeight: 100, parentElement: {scrollTop: 10}}};
             wrapper.setProps({atOldestPost: true});
             wrapper.setState({atBottom: true});
-            expect(instance.componentDidUpdate.mock.calls[1][2]).toEqual(null);
+            expect(spy.mock.calls[1][2]).toEqual(null);
         });
     });
 

--- a/components/post_view/post_list_virtualized/post_list_virtualized.tsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.tsx
@@ -137,7 +137,7 @@ export interface PostListProps extends WrappedComponentProps<'intl'> {
 
     latestPostTimeStamp: number;
     latestAriaLabelFunc?: (ariaLabel: IntlShape) => SpanAttribute;
-    lastViewedAt: string | Timestamp;
+    lastViewedAt?: string | Timestamp;
 
     actions: PostListActions;
 };
@@ -710,3 +710,4 @@ class PostList extends React.PureComponent<PostListProps, PostListState, Snapsho
 }
 
 export default injectIntl(PostList);
+export { PostList as PostListType}

--- a/components/post_view/post_list_virtualized/post_list_virtualized.tsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.tsx
@@ -47,7 +47,10 @@ type RowData = {
     itemId: string;
     style?: CSSProperties;
 };
-
+type DynamicSizeListDimensions = {
+    width: number;
+    height: number;
+}
 type OnItemsRenderedArgs = {
 
     /**
@@ -94,7 +97,7 @@ type ScrollPosition = {
     previousScrollHeight: number;
 };
 
-type Snapshot = ScrollPosition | null;
+export type Snapshot = ScrollPosition | null;
 
 export interface PostListProps extends WrappedComponentProps<'intl'> {
 
@@ -164,7 +167,7 @@ interface PostListActions {
      */
     checkAndSetMobileView: () => void;
 
-    changeUnreadChunkTimeStamp: (lastViewedAt: string | Timestamp | ReactText) => void;
+    changeUnreadChunkTimeStamp: (lastViewedAt: string | Timestamp | ReactText | undefined) => void;
     updateNewMessagesAtInChannel: (channelId: string, lastViewedAt: Timestamp) => void;
 
 }
@@ -672,7 +675,7 @@ class PostList extends React.PureComponent<PostListProps, PostListState, Snapsho
                                 {ariaLabel}
                             </span>
                             <AutoSizer>
-                                {({height, width}: any) => (
+                                {({height, width}: DynamicSizeListDimensions) => (
                                     <React.Fragment>
                                         <div>{this.renderToasts(width)}</div>
 

--- a/components/post_view/post_list_virtualized/post_list_virtualized.tsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.tsx
@@ -140,7 +140,7 @@ export interface PostListProps extends WrappedComponentProps<'intl'> {
     lastViewedAt?: string | Timestamp;
 
     actions: PostListActions;
-};
+}
 
 interface PostListActions {
 
@@ -167,7 +167,7 @@ interface PostListActions {
     changeUnreadChunkTimeStamp: (lastViewedAt: string | Timestamp | ReactText) => void;
     updateNewMessagesAtInChannel: (channelId: string, lastViewedAt: Timestamp) => void;
 
-};
+}
 
 export type PostListState = {
     isScrolling: boolean;
@@ -710,4 +710,4 @@ class PostList extends React.PureComponent<PostListProps, PostListState, Snapsho
 }
 
 export default injectIntl(PostList);
-export { PostList as PostListType}
+export {PostList as PostListType};

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "@types/react-router-dom": "5.1.7",
     "@types/react-select": "3.0.19",
     "@types/react-transition-group": "4.4.1",
+    "@types/react-virtualized-auto-sizer": "1.0.1",
     "@types/redux-mock-store": "1.0.2",
     "@types/shallow-equals": "1.0.0",
     "@types/tinycolor2": "1.4.2",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
This Pull Request migrates 'components/post_view/post_list_virtualized' and associated tests to TypeScript as in this issue:
https://github.com/mattermost/mattermost-server/issues/17289
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
JIRA: https://mattermost.atlassian.net/browse/MM-34366
issue: https://github.com/mattermost/mattermost-server/issues/17289
#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has no server changes
- Has no mobile changes

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
No UI changes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE

```
